### PR TITLE
fix: Typo Error

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const mongoose = require('mongoose')
 
 mongoose.Promise = require('bluebird')
 
-mongoose.connect(`mongodb://mongo:27017}`).then(
+mongoose.connect(`mongodb://mongo:27017`).then(
   () => {
     console.log('connected to database')
   }


### PR DESCRIPTION
Fixed a typo where I had an } as part of the mongo uri that was not
needed.